### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-documentation-site.yml
+++ b/.github/workflows/deploy-documentation-site.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout gplint.github.io repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/gplint/gplint.github.io/security/code-scanning/1](https://github.com/gplint/gplint.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job, specifying the least privileges required. Based on the workflow's actions, the `build` job only needs `contents: read` to fetch repository data and `pull-requests: read` to access pull request details via the GitHub API. These permissions will restrict the `GITHUB_TOKEN` to read-only access for repository contents and pull requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
